### PR TITLE
test: add Node.js 10 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
   - "7.10"
   - "8.11"
   - "9.11"
+  - "10.12"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
I'm not really sure why the other test-versions are pinned to a specific minor. Shouldn't they always just run against the latest minor, or is the pinned minor there to test against a specific bug in that version?