### PR TITLE
fix: call destroy() on readable-stream streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Destroy the given stream. In most cases, this is identical to a simple
      and add a listener to the `open` event to call `stream.close()` if it is
      fired. This is for a Node.js bug that will leak a file descriptor if
      `.destroy()` is called before `open`.
-  2. If the `stream` is not an instance of `Stream`, then nothing happens.
-  3. If the `stream` has a `.destroy()` method, then call it.
+  1. If the `stream` has a `.destroy()` method, then call it.
 
 The function returns the `stream` passed in as the argument.
 

--- a/index.js
+++ b/index.js
@@ -29,12 +29,12 @@ module.exports = destroy
  */
 
 function destroy (stream) {
-  if (stream instanceof ReadStream) {
-    return destroyReadStream(stream)
+  if (!stream) {
+    return stream
   }
 
-  if (!(stream instanceof Stream)) {
-    return stream
+  if (stream instanceof ReadStream) {
+    return destroyReadStream(stream)
   }
 
   if (typeof stream.destroy === 'function') {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",
     "istanbul": "0.4.5",
-    "mocha": "2.5.3"
+    "mocha": "2.5.3",
+    "readable-stream": "^3.0.6"
   },
   "engines": {
     "node": ">= 0.8",

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 var assert = require('assert')
 var fs = require('fs')
 var net = require('net')
+var readableStream = require('readable-stream')
 
 var destroy = require('..')
 
@@ -54,6 +55,15 @@ describe('destroy', function () {
 
       cleanup()
       done()
+    })
+  })
+
+  describe('readable-stream', function () {
+    it('should destroy readable-stream streams', function () {
+      var stream = new readableStream.PassThrough()
+      assert(!isdestroyed(stream))
+      destroy(stream)
+      assert(isdestroyed(stream))
     })
   })
 


### PR DESCRIPTION
Checking for if `stream` was an instance of `Stream` would wrongly ignore [readable-stream](https://github.com/nodejs/readable-stream) streams. This PR changes that to just always call `destroy()` if the function exists.